### PR TITLE
Add a transaction detail endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3,6 +3,7 @@ use futures::future::{Future};
 
 use futures::{future::ok};
 
+use serde_json::json;
 
 
 use crate::db;
@@ -56,13 +57,24 @@ pub fn get_transaction(params: web::Path<datastruct::IdRequest>) -> impl Future<
     } 
 }
 
-pub fn get_transaction_detail(params: web::Path<datastruct::IdRequest>) -> impl Future<Item = HttpResponse, Error = Error> {
-    let result = db::get_transaction(params.id);
 
-    match result {
-        Ok(v) => ok(HttpResponse::Ok().json(v)),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
-    } 
+pub fn get_transaction_detail(params: web::Path<datastruct::IdRequest>) -> impl Future<Item = HttpResponse, Error = Error> {
+    let transaction = db::get_transaction(params.id);
+    let debit = db::get_debit(params.id);
+    let credit = db::get_credit(params.id);
+
+    if transaction.is_err() || debit.is_err() || credit.is_err() {
+        return ok(HttpResponse::InternalServerError().finish());
+    }
+
+    let result = json!({
+        "transaction": transaction.unwrap(),
+        "debit": debit.unwrap(),
+        "credit": credit.unwrap()
+    });
+
+
+    ok(HttpResponse::Ok().json(result))
 }
 
 pub fn get_account(params: web::Path<datastruct::IdRequest>) -> impl Future<Item = HttpResponse, Error = Error> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -56,6 +56,15 @@ pub fn get_transaction(params: web::Path<datastruct::IdRequest>) -> impl Future<
     } 
 }
 
+pub fn get_transaction_detail(params: web::Path<datastruct::IdRequest>) -> impl Future<Item = HttpResponse, Error = Error> {
+    let result = db::get_transaction(params.id);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    } 
+}
+
 pub fn get_account(params: web::Path<datastruct::IdRequest>) -> impl Future<Item = HttpResponse, Error = Error> {
     let result = db::get_account_by_id(params.id);
 

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -61,6 +61,14 @@ pub struct Transaction {
 }
 
 #[derive(Debug, Serialize)]
+pub struct Entry {
+    pub id: i32,
+    pub account: i32,
+    pub transaction_id: i32,
+    pub balance: f64
+}
+
+#[derive(Debug, Serialize)]
 pub struct SqlResult {
     pub value: f64
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 use rusqlite::{Connection, Result, params, NO_PARAMS};
-use crate::datastruct::{Account, AccountType, Transaction, SqlResult};
+use crate::datastruct::{Account, AccountType, Transaction, SqlResult, Entry};
 
 use chrono::{DateTime, Utc};
 
@@ -167,5 +167,34 @@ pub fn current_balance(account : i32 ) -> Result<(SqlResult)> {
     }))
 
 }
+
+pub fn get_debit(id : i32) -> Result<(Entry)> {
+    let conn = Connection::open("ledger.db")?;
+    let mut stmt = conn.prepare("SELECT id, account, transaction_id, balance from Debits WHERE transaction_id = ?1;")?;
+
+
+    stmt.query_row(params![id], |row|
+       Ok(Entry {
+           id: row.get(0).unwrap(),
+           account: row.get(1).unwrap(),
+           transaction_id: row.get(2).unwrap(),
+           balance: row.get(2).unwrap(),
+       }))
+}
+
+pub fn get_credit(id : i32) -> Result<(Entry)> {
+    let conn = Connection::open("ledger.db")?;
+    let mut stmt = conn.prepare("SELECT id, account, transaction_id, balance from Credits WHERE transaction_id = ?1;")?;
+
+
+    stmt.query_row(params![id], |row|
+       Ok(Entry {
+           id: row.get(0).unwrap(),
+           account: row.get(1).unwrap(),
+           transaction_id: row.get(2).unwrap(),
+           balance: row.get(2).unwrap(),
+       }))
+}
+
 
 // SELECT t.date, t.name,  c.account as "from", c.balance as "Credit", d.account as "to",  d.balance as "Debit" FROM Transactions as t LEFT JOIN Debits as d ON d.transaction_id = t.id LEFT JOIN Credits as c ON c.transaction_id = t.id WHERE t.id = 8;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> io::Result<()> {
                 )
                 .service(
                     web::resource("/{id}/detail")
-                        .route(web::get().to_async(api::get_transaction))
+                        .route(web::get().to_async(api::get_transaction_detail))
                 )
             )
             .service(web::scope("/account")

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,10 @@ fn main() -> io::Result<()> {
                         .route(web::get().to_async(api::get_transaction))
                         .route(web::delete().to_async(api::delete_transaction)),
                 )
+                .service(
+                    web::resource("/{id}/detail")
+                        .route(web::get().to_async(api::get_transaction))
+                )
             )
             .service(web::scope("/account")
                 .service(web::resource("/").route(web::post().to_async(api::create_account)))


### PR DESCRIPTION
In this PR:
- Added a very simple implementation of an endpoint that is able to report on the transaction and its debits and credits. 
- Right now the implementation is very lazy
- Added an entry struct, which can be reusable between debits and credits