### PR TITLE
Implement Account Currency Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target/
 **/*.rs.bk
 *.db
+*.db-journal
 *.csv
 
 .vscode

--- a/data/create.sql
+++ b/data/create.sql
@@ -27,3 +27,11 @@ CREATE TABLE "Transactions" (
 	"date"	TEXT NOT NULL,
 	"name"	TEXT
 )
+
+CREATE TABLE "Currency" (
+	"code"	TEXT NOT NULL UNIQUE,
+	"numeric_code"	INTEGER NOT NULL UNIQUE,
+	"minor_unit"	INTEGER DEFAULT 2,
+	"name"	TEXT NOT NULL UNIQUE,
+	PRIMARY KEY("code")
+)

--- a/data/create.sql
+++ b/data/create.sql
@@ -31,7 +31,7 @@ CREATE TABLE "Transactions" (
 CREATE TABLE "Currency" (
 	"code"	TEXT NOT NULL UNIQUE,
 	"numeric_code"	INTEGER NOT NULL UNIQUE,
-	"minor_unit"	INTEGER DEFAULT 2,
+	"minor_unit"	INTEGER NOT NULL DEFAULT 2,
 	"name"	TEXT NOT NULL UNIQUE,
 	PRIMARY KEY("code")
 )

--- a/data/create.sql
+++ b/data/create.sql
@@ -1,7 +1,9 @@
 CREATE TABLE "Accounts" (
 	"id"	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-	"Type"	INTEGER NOT NULL,
-	"Name"	TEXT NOT NULL
+	"type"	INTEGER NOT NULL,
+	"name"	TEXT NOT NULL,
+	"currency"	TEXT NOT NULL,
+	FOREIGN KEY("currency") REFERENCES "Currency"("code")
 )
 
 CREATE TABLE "Credits" (

--- a/src/api.rs
+++ b/src/api.rs
@@ -147,3 +147,15 @@ pub fn get_account_balance(
         Err(_e) => ok(HttpResponse::InternalServerError().finish()),
     }
 }
+
+pub fn list_currencies(
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let conn = pool.get().unwrap();
+    let result = db::list_currencies(conn);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -116,7 +116,7 @@ pub fn create_account(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     let account_type = datastruct::AccountType::from_i32(account.acc_type);
-    let result = db::add_account(pool.get().unwrap(), account_type, &account.name);
+    let result = db::add_account(pool.get().unwrap(), account_type, &account.name, &account.currency);
 
     match result {
         Ok(v) => ok(HttpResponse::Ok().json(v)),

--- a/src/api.rs
+++ b/src/api.rs
@@ -180,25 +180,6 @@ pub fn list_currencies(
 mod tests {
     use super::*;
     use crate::datastruct::{Account, AccountType};
-    #[test]
-    fn accounts_not_compatible_if_id_equal() {
-        let first = Account {
-            id: 0,
-            acc_type: AccountType::Assets,
-            name: String::from("Current"),
-            currency: String::from("GBP"),
-        };
-        let second = Account {
-            id: 0,
-            acc_type: AccountType::Assets,
-            name: String::from("Current"),
-            currency: String::from("GBP"),
-        };
-
-        let result = are_accounts_compatible(&first, &second);
-
-        assert_eq!(result, false)
-    }
 
     #[test]
     fn accounts_compatible() {
@@ -212,6 +193,26 @@ mod tests {
             id: 1,
             acc_type: AccountType::Expenses,
             name: String::from("Groceries"),
+            currency: String::from("GBP"),
+        };
+
+        let result = are_accounts_compatible(&first, &second);
+
+        assert_eq!(result, true)
+    }
+
+    #[test]
+    fn accounts_not_compatible_if_id_equal() {
+        let first = Account {
+            id: 0,
+            acc_type: AccountType::Assets,
+            name: String::from("Current"),
+            currency: String::from("GBP"),
+        };
+        let second = Account {
+            id: 0,
+            acc_type: AccountType::Assets,
+            name: String::from("Current"),
             currency: String::from("GBP"),
         };
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,6 +32,13 @@ pub fn list_transactions() -> impl Future<Item = HttpResponse, Error = Error> {
     }
 }
 
+fn are_accounts_compatible(from : &datastruct::Account, to : &datastruct::Account) -> bool {
+    if &from.id == &to.id || &from.currency != &to.currency {
+        return false;
+    }
+    return true;
+}
+
 pub fn create_transaction(
     transaction: web::Json<datastruct::NewTransaction>,
     pool: web::Data<Pool<SqliteConnectionManager>>,
@@ -39,17 +46,21 @@ pub fn create_transaction(
     let from_account = db::get_account(pool.get().unwrap(), &transaction.from).unwrap();
     let to_account = db::get_account(pool.get().unwrap(), &transaction.to).unwrap();
 
-    let result = db::transaction(
-        pool.get().unwrap(),
-        to_account.id,
-        from_account.id,
-        transaction.balance,
-        &transaction.name,
-    );
+    if are_accounts_compatible(&from_account, &to_account) == false {
+        ok(HttpResponse::BadRequest().finish())
+    } else {
+        let result = db::transaction(
+            pool.get().unwrap(),
+            to_account.id,
+            from_account.id,
+            transaction.balance,
+            &transaction.name,
+        );
 
-    match result {
-        Ok(_v) => ok(HttpResponse::Ok().finish()),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+        match result {
+            Ok(_v) => ok(HttpResponse::Ok().finish()),
+            Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+        }
     }
 }
 
@@ -162,5 +173,70 @@ pub fn list_currencies(
     match result {
         Ok(v) => ok(HttpResponse::Ok().json(v)),
         Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastruct::{Account, AccountType};
+    #[test]
+    fn accounts_not_compatible_if_id_equal() {
+        let first = Account {
+            id: 0,
+            acc_type: AccountType::Assets,
+            name: String::from("Current"),
+            currency: String::from("GBP")
+        };
+        let second = Account {
+            id: 0,
+            acc_type: AccountType::Assets,
+            name: String::from("Current"),
+            currency: String::from("GBP")
+        };
+
+        let result = are_accounts_compatible(&first, &second);
+
+        assert_eq!(result, false)
+    }
+
+    #[test]
+    fn accounts_compatible() {
+        let first = Account {
+            id: 0,
+            acc_type: AccountType::Assets,
+            name: String::from("Current"),
+            currency: String::from("GBP")
+        };
+        let second = Account {
+            id: 1,
+            acc_type: AccountType::Expenses,
+            name: String::from("Groceries"),
+            currency: String::from("GBP")
+        };
+
+        let result = are_accounts_compatible(&first, &second);
+
+        assert_eq!(result, false)
+    }
+
+    #[test]
+    fn accounts_not_compatible_if_different_currencies() {
+        let first = Account {
+            id: 0,
+            acc_type: AccountType::Assets,
+            name: String::from("Current"),
+            currency: String::from("GBP")
+        };
+        let second = Account {
+            id: 1,
+            acc_type: AccountType::Expenses,
+            name: String::from("Groceries"),
+            currency: String::from("EUR")
+        };
+
+        let result = are_accounts_compatible(&first, &second);
+
+        assert_eq!(result, false)
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -116,7 +116,12 @@ pub fn create_account(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     let account_type = datastruct::AccountType::from_i32(account.acc_type);
-    let result = db::add_account(pool.get().unwrap(), account_type, &account.name, &account.currency);
+    let result = db::add_account(
+        pool.get().unwrap(),
+        account_type,
+        &account.name,
+        &account.currency,
+    );
 
     match result {
         Ok(v) => ok(HttpResponse::Ok().json(v)),

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,7 +32,7 @@ pub fn list_transactions() -> impl Future<Item = HttpResponse, Error = Error> {
     }
 }
 
-fn are_accounts_compatible(from : &datastruct::Account, to : &datastruct::Account) -> bool {
+fn are_accounts_compatible(from: &datastruct::Account, to: &datastruct::Account) -> bool {
     if &from.id == &to.id || &from.currency != &to.currency {
         return false;
     }
@@ -186,13 +186,13 @@ mod tests {
             id: 0,
             acc_type: AccountType::Assets,
             name: String::from("Current"),
-            currency: String::from("GBP")
+            currency: String::from("GBP"),
         };
         let second = Account {
             id: 0,
             acc_type: AccountType::Assets,
             name: String::from("Current"),
-            currency: String::from("GBP")
+            currency: String::from("GBP"),
         };
 
         let result = are_accounts_compatible(&first, &second);
@@ -206,13 +206,13 @@ mod tests {
             id: 0,
             acc_type: AccountType::Assets,
             name: String::from("Current"),
-            currency: String::from("GBP")
+            currency: String::from("GBP"),
         };
         let second = Account {
             id: 1,
             acc_type: AccountType::Expenses,
             name: String::from("Groceries"),
-            currency: String::from("GBP")
+            currency: String::from("GBP"),
         };
 
         let result = are_accounts_compatible(&first, &second);
@@ -226,13 +226,13 @@ mod tests {
             id: 0,
             acc_type: AccountType::Assets,
             name: String::from("Current"),
-            currency: String::from("GBP")
+            currency: String::from("GBP"),
         };
         let second = Account {
             id: 1,
             acc_type: AccountType::Expenses,
             name: String::from("Groceries"),
-            currency: String::from("EUR")
+            currency: String::from("EUR"),
         };
 
         let result = are_accounts_compatible(&first, &second);

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -72,3 +72,11 @@ pub struct Entry {
 pub struct SqlResult {
     pub value: f64,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Currency {
+    pub code: String,
+    pub numeric_code: i32,
+    pub minor_unit: i32,
+    pub name: String
+}

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -32,6 +32,7 @@ pub struct Account {
     pub id: i32,
     pub acc_type: AccountType,
     pub name: String,
+    pub currency: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -46,6 +47,7 @@ pub struct NewTransaction {
 pub struct NewAccount {
     pub acc_type: i32,
     pub name: String,
+    pub currency: String
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -75,7 +75,7 @@ pub struct SqlResult {
     pub value: f64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Currency {
     pub code: String,
     pub numeric_code: i32,

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -47,7 +47,7 @@ pub struct NewTransaction {
 pub struct NewAccount {
     pub acc_type: i32,
     pub name: String,
-    pub currency: String
+    pub currency: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -80,5 +80,5 @@ pub struct Currency {
     pub code: String,
     pub numeric_code: i32,
     pub minor_unit: i32,
-    pub name: String
+    pub name: String,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -275,3 +275,48 @@ pub fn list_currencies(
 
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use r2d2_sqlite::SqliteConnectionManager;
+    use rusqlite::params;
+    use super::*;
+    #[test]
+    fn lists_currencies() {
+        let manager = SqliteConnectionManager::memory();
+        let pool = r2d2::Pool::new(manager).unwrap();
+        let conn = pool.get().unwrap();
+
+        let _ = conn.execute(
+            "CREATE TABLE \"Currency\" (
+	        \"code\"	TEXT NOT NULL UNIQUE,
+	        \"numeric_code\"	INTEGER NOT NULL UNIQUE,
+	        \"minor_unit\"	INTEGER NOT NULL DEFAULT 2,
+	        \"name\"	TEXT NOT NULL UNIQUE,
+	        PRIMARY KEY(\"code\")
+            )",
+            params![],
+        );
+
+        let num = conn.execute(
+            "INSERT INTO Currency (code, numeric_code, minor_unit, name) VALUES ('GBP', '826', '2', 'Pound Sterling');",
+            params![],
+        );
+
+        assert_eq!(num.unwrap(), 1);
+
+
+        let expected = vec![Currency{
+           code: String::from("GBP"),
+           numeric_code: 826,
+           minor_unit: 2,
+           name: String::from("Pound Sterling")
+        }];
+        let result = list_currencies(conn).unwrap();
+
+        assert_eq!(expected[0].code, result[0].code);
+        assert_eq!(expected[0].numeric_code, result[0].numeric_code);
+        assert_eq!(expected[0].minor_unit, result[0].minor_unit);
+        assert_eq!(expected[0].name, result[0].name);
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-use crate::datastruct::{Account, AccountType, Entry, SqlResult, Transaction};
+use crate::datastruct::{Account, AccountType, Entry, SqlResult, Transaction, Currency};
 use rusqlite::{params, Connection, Result, NO_PARAMS};
 
 use chrono::{DateTime, Utc};
@@ -248,3 +248,26 @@ pub fn get_credit(
 }
 
 // SELECT t.date, t.name,  c.account as "from", c.balance as "Credit", d.account as "to",  d.balance as "Debit" FROM Transactions as t LEFT JOIN Debits as d ON d.transaction_id = t.id LEFT JOIN Credits as c ON c.transaction_id = t.id WHERE t.id = 8;
+
+pub fn list_currencies(
+    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+) -> Result<(Vec<Currency>)> {
+    let mut stmt = conn.prepare("SELECT code, numeric_code, minor_unit FROM Currency")?;
+
+    let result = stmt
+        .query_map(NO_PARAMS, |row| {
+            Ok(Currency {
+                code: row.get(0).unwrap(),
+                numeric_code: row.get(1).unwrap(),
+                minor_unit: row.get(2).unwrap(),
+                name: row.get(3).unwrap()
+            })
+        })
+        .and_then(|mapped_rows| {
+            Ok(mapped_rows
+                .map(|row| row.unwrap())
+                .collect::<Vec<Currency>>())
+        })?;
+
+    Ok(result)
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -252,7 +252,7 @@ pub fn get_credit(
 pub fn list_currencies(
     conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
 ) -> Result<(Vec<Currency>)> {
-    let mut stmt = conn.prepare("SELECT code, numeric_code, minor_unit FROM Currency")?;
+    let mut stmt = conn.prepare("SELECT code, numeric_code, minor_unit, name FROM Currency")?;
 
     let result = stmt
         .query_map(NO_PARAMS, |row| {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-use crate::datastruct::{Account, AccountType, Entry, SqlResult, Transaction, Currency};
+use crate::datastruct::{Account, AccountType, Currency, Entry, SqlResult, Transaction};
 use rusqlite::{params, Connection, Result, NO_PARAMS};
 
 use chrono::{DateTime, Utc};
@@ -99,7 +99,7 @@ pub fn add_account(
     mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
     acc_type: AccountType,
     name: &str,
-    currency: &str
+    currency: &str,
 ) -> Result<()> {
     let con = conn.deref_mut();
     let tx = con.transaction()?;
@@ -264,7 +264,7 @@ pub fn list_currencies(
                 code: row.get(0).unwrap(),
                 numeric_code: row.get(1).unwrap(),
                 minor_unit: row.get(2).unwrap(),
-                name: row.get(3).unwrap()
+                name: row.get(3).unwrap(),
             })
         })
         .and_then(|mapped_rows| {

--- a/src/db.rs
+++ b/src/db.rs
@@ -278,9 +278,9 @@ pub fn list_currencies(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use r2d2_sqlite::SqliteConnectionManager;
     use rusqlite::params;
-    use super::*;
     #[test]
     fn lists_currencies_returns_struct() {
         let manager = SqliteConnectionManager::memory();
@@ -305,12 +305,11 @@ mod tests {
 
         assert_eq!(num.unwrap(), 1);
 
-
         let expected = Currency {
-           code: String::from("GBP"),
-           numeric_code: 826,
-           minor_unit: 2,
-           name: String::from("Pound Sterling")
+            code: String::from("GBP"),
+            numeric_code: 826,
+            minor_unit: 2,
+            name: String::from("Pound Sterling"),
         };
         let result = list_currencies(conn).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,9 @@ fn main() -> io::Result<()> {
                 web::resource("/transactions").route(web::get().to_async(api::list_transactions)),
             )
             .service(
+                web::resource("/currencies").route(web::get().to_async(api::list_currencies)),
+            )
+            .service(
                 web::scope("/transaction")
                     .service(
                         web::resource("/").route(web::post().to_async(api::create_transaction)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,9 +50,7 @@ fn main() -> io::Result<()> {
             .service(
                 web::resource("/transactions").route(web::get().to_async(api::list_transactions)),
             )
-            .service(
-                web::resource("/currencies").route(web::get().to_async(api::list_currencies)),
-            )
+            .service(web::resource("/currencies").route(web::get().to_async(api::list_currencies)))
             .service(
                 web::scope("/transaction")
                     .service(


### PR DESCRIPTION
In this PR:
- Added Currency information to the main ledger database
- Added the `currency` field to the Account object
- Added the first two unit tests (This will probably need refactoring)
- Modified the accounts api to return currency as a field
- Added a currency endpoint which lists all current currencies
- Restricted the creation of transactions to:
  - Accounts of the same currency
  - Accounts must be different
