### PR TITLE
Refactor the transaction api

### DIFF
--- a/data/create.sql
+++ b/data/create.sql
@@ -10,7 +10,7 @@ CREATE TABLE "Credits" (
 	"id"	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
 	"account"	INTEGER NOT NULL,
 	"transaction_id"	INTEGER NOT NULL,
-	"balance"	REAL NOT NULL DEFAULT 0.0,
+	"balance"	INTEGER NOT NULL DEFAULT 0 CHECK (typeof("balance") = 'integer'),
 	FOREIGN KEY("account") REFERENCES "Accounts"("id"),
 	FOREIGN KEY("transaction_id") REFERENCES "Transactions"("id") ON DELETE CASCADE
 )
@@ -19,7 +19,7 @@ CREATE TABLE "Debits" (
 	"id"	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
 	"account"	INTEGER NOT NULL,
 	"transaction_id"	INTEGER NOT NULL,
-	"balance"	REAL NOT NULL DEFAULT 0.0,
+	"balance"	INTEGER NOT NULL DEFAULT 0 CHECK (typeof("balance") = 'integer'),
 	FOREIGN KEY("account") REFERENCES "Accounts"("id"),
 	FOREIGN KEY("transaction_id") REFERENCES "Transactions"("id") ON DELETE CASCADE
 )

--- a/src/api.rs
+++ b/src/api.rs
@@ -113,17 +113,15 @@ pub fn get_transaction_detail(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     let transaction = db::get_transaction(pool.get().unwrap(), params.id);
-    let debit = db::get_debit(pool.get().unwrap(), params.id);
-    let credit = db::get_credit(pool.get().unwrap(), params.id);
+    let entries = db::get_entries(pool.get().unwrap(), params.id);
 
-    if transaction.is_err() || debit.is_err() || credit.is_err() {
+    if transaction.is_err() || entries.is_err() {
         return ok(HttpResponse::InternalServerError().finish());
     }
 
     let result = json!({
         "transaction": transaction.unwrap(),
-        "debit": debit.unwrap(),
-        "credit": credit.unwrap()
+        "entries": entries.unwrap(),
     });
 
     ok(HttpResponse::Ok().json(result))

--- a/src/api.rs
+++ b/src/api.rs
@@ -66,7 +66,13 @@ pub fn create_transaction(
         );
 
         match result {
-            Ok(_v) => ok(HttpResponse::Ok().finish()),
+            Ok(v) => {
+                let result = json!({
+                    "id": v,
+                });
+
+                ok(HttpResponse::Ok().json(result))
+            }
             Err(_e) => ok(HttpResponse::InternalServerError().finish()),
         }
     }
@@ -79,7 +85,13 @@ pub fn delete_transaction(
     let result = db::remove_transaction(pool.get().unwrap(), params.id);
 
     match result {
-        Ok(_v) => ok(HttpResponse::Ok().finish()),
+        Ok(_v) => {
+                let result = json!({
+                    "id": params.id,
+                });
+
+                ok(HttpResponse::Ok().json(result))
+            }
         Err(_e) => ok(HttpResponse::InternalServerError().finish()),
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -134,7 +134,7 @@ pub fn get_account(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     let conn = pool.get().unwrap();
-    let result = db::get_account_by_id(conn, params.id);
+    let result = db::get_account(conn, params.id);
 
     match result {
         Ok(v) => ok(HttpResponse::Ok().json(v)),
@@ -192,6 +192,23 @@ pub fn list_currencies(
 
     match result {
         Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
+pub fn check_ledger_integrity(
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let conn = pool.get().unwrap();
+    let result = db::check_integrity(conn);
+
+    match result {
+        Ok(v) => {
+            let result = json!({
+                "integrity": v,
+            });
+            ok(HttpResponse::Ok().json(result))
+        }
         Err(_e) => ok(HttpResponse::InternalServerError().finish()),
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -86,12 +86,12 @@ pub fn delete_transaction(
 
     match result {
         Ok(_v) => {
-                let result = json!({
-                    "id": params.id,
-                });
+            let result = json!({
+                "id": params.id,
+            });
 
-                ok(HttpResponse::Ok().json(result))
-            }
+            ok(HttpResponse::Ok().json(result))
+        }
         Err(_e) => ok(HttpResponse::InternalServerError().finish()),
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -44,8 +44,8 @@ pub fn create_transaction(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     // First we get the two accounts
-    let from_acc_query = db::get_account_by_id(pool.get().unwrap(), transaction.from);
-    let to_acc_query = db::get_account_by_id(pool.get().unwrap(), transaction.to);
+    let from_acc_query = db::get_account(pool.get().unwrap(), transaction.from);
+    let to_acc_query = db::get_account(pool.get().unwrap(), transaction.to);
 
     if from_acc_query.is_err() || to_acc_query.is_err() {
         return ok(HttpResponse::BadRequest().finish());

--- a/src/api.rs
+++ b/src/api.rs
@@ -44,8 +44,8 @@ pub fn create_transaction(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     // First we get the two accounts
-    let from_acc_query = db::get_account(pool.get().unwrap(), &transaction.from);
-    let to_acc_query = db::get_account(pool.get().unwrap(), &transaction.to);
+    let from_acc_query = db::get_account_by_id(pool.get().unwrap(), transaction.from);
+    let to_acc_query = db::get_account_by_id(pool.get().unwrap(), transaction.to);
 
     if from_acc_query.is_err() || to_acc_query.is_err() {
         return ok(HttpResponse::BadRequest().finish());

--- a/src/api.rs
+++ b/src/api.rs
@@ -164,7 +164,7 @@ pub fn delete_account(
     params: web::Path<datastruct::IdRequest>,
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    let result = db::remove_account_by_id(pool.get().unwrap(), params.id);
+    let result = db::remove_account(pool.get().unwrap(), params.id);
 
     match result {
         Ok(_v) => ok(HttpResponse::Ok().finish()),

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -39,8 +39,8 @@ pub struct Account {
 pub struct NewTransaction {
     pub name: String,
     pub balance: f64,
-    pub from: String,
-    pub to: String,
+    pub from: i32,
+    pub to: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -54,7 +54,7 @@ pub struct Account {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NewTransaction {
     pub name: String,
-    pub balance: f64,
+    pub balance: i32,
     pub from: i32,
     pub to: i32,
 }
@@ -83,7 +83,7 @@ pub struct Entry {
     pub id: i32,
     pub account: i32,
     pub transaction_id: i32,
-    pub balance: f64,
+    pub balance: i32,
     pub entry_type: EntryType,
 }
 

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -71,6 +71,12 @@ pub struct IdRequest {
     pub id: i32,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DateRequest {
+    pub year: i32,
+    pub month: u8,
+}
+
 #[derive(Debug, Serialize)]
 pub struct Transaction {
     pub id: i32,

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -27,6 +27,29 @@ impl AccountType {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Copy, Clone)]
+pub enum EntryType {
+    Debit,
+    Credit,
+}
+
+impl EntryType {
+    pub fn opposite(other: EntryType) -> EntryType {
+        match other {
+            EntryType::Debit => EntryType::Credit,
+            EntryType::Credit => EntryType::Debit,
+        }
+    }
+
+    pub fn from_i32(value: i32) -> EntryType {
+        match value {
+            0 => EntryType::Credit,
+            1 => EntryType::Debit,
+            _ => panic!("Unknown value: {}", value),
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct Account {
     pub id: i32,
@@ -68,6 +91,7 @@ pub struct Entry {
     pub account: i32,
     pub transaction_id: i32,
     pub balance: f64,
+    pub entry_type: EntryType,
 }
 
 #[derive(Debug, Serialize)]
@@ -81,4 +105,28 @@ pub struct Currency {
     pub numeric_code: i32,
     pub minor_unit: i32,
     pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_correctly_types() {
+        let debit = EntryType::from_i32(1);
+        let credit = EntryType::from_i32(0);
+
+        assert_eq!(debit, EntryType::Debit);
+        assert_eq!(credit, EntryType::Credit)
+    }
+
+    #[test]
+    fn entry_correctly_finds_opposite() {
+        let credit = EntryType::opposite(EntryType::Debit);
+        let debit = EntryType::opposite(EntryType::Credit);
+
+        assert_eq!(debit, EntryType::Debit);
+        assert_eq!(credit, EntryType::Credit)
+    }
+
 }

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -34,13 +34,6 @@ pub enum EntryType {
 }
 
 impl EntryType {
-    pub fn opposite(other: EntryType) -> EntryType {
-        match other {
-            EntryType::Debit => EntryType::Credit,
-            EntryType::Credit => EntryType::Debit,
-        }
-    }
-
     pub fn from_i32(value: i32) -> EntryType {
         match value {
             0 => EntryType::Credit,
@@ -119,14 +112,4 @@ mod tests {
         assert_eq!(debit, EntryType::Debit);
         assert_eq!(credit, EntryType::Credit)
     }
-
-    #[test]
-    fn entry_correctly_finds_opposite() {
-        let credit = EntryType::opposite(EntryType::Debit);
-        let debit = EntryType::opposite(EntryType::Credit);
-
-        assert_eq!(debit, EntryType::Debit);
-        assert_eq!(credit, EntryType::Credit)
-    }
-
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -142,7 +142,7 @@ pub fn transaction(
     credit_account: i32,
     balance: f64,
     name: &str,
-) -> Result<()> {
+) -> Result<i64> {
     let con = conn.deref_mut();
     let tx = con.transaction()?;
     let date: DateTime<Utc> = Utc::now();
@@ -163,7 +163,12 @@ pub fn transaction(
         params![credit_account, transaction_id, balance],
     )?;
 
-    tx.commit()
+    let transaction_result = tx.commit();
+
+    match transaction_result {
+        Ok(_) => Ok(transaction_id),
+        Err(_) => panic!("Transaction has failed"),
+    }
 }
 
 pub fn remove_transaction(

--- a/src/db.rs
+++ b/src/db.rs
@@ -112,7 +112,7 @@ pub fn transaction(
     mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
     debit_account: i32,
     credit_account: i32,
-    balance: f64,
+    balance: i32,
     name: &str,
 ) -> Result<i64> {
     let con = conn.deref_mut();

--- a/src/db.rs
+++ b/src/db.rs
@@ -192,44 +192,6 @@ pub fn current_balance(
     })
 }
 
-pub fn get_debit(
-    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    id: i32,
-) -> Result<(Entry)> {
-    let mut stmt = conn.prepare(
-        "SELECT id, account, transaction_id, balance from Debits WHERE transaction_id = ?1;",
-    )?;
-
-    stmt.query_row(params![id], |row| {
-        Ok(Entry {
-            id: row.get(0).unwrap(),
-            account: row.get(1).unwrap(),
-            transaction_id: row.get(2).unwrap(),
-            balance: row.get(3).unwrap(),
-            entry_type: EntryType::Debit,
-        })
-    })
-}
-
-pub fn get_credit(
-    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    id: i32,
-) -> Result<(Entry)> {
-    let mut stmt = conn.prepare(
-        "SELECT id, account, transaction_id, balance from Credits WHERE transaction_id = ?1;",
-    )?;
-
-    stmt.query_row(params![id], |row| {
-        Ok(Entry {
-            id: row.get(0).unwrap(),
-            account: row.get(1).unwrap(),
-            transaction_id: row.get(2).unwrap(),
-            balance: row.get(3).unwrap(),
-            entry_type: EntryType::Credit,
-        })
-    })
-}
-
 pub fn get_entries(
     conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
     id: i32,

--- a/src/db.rs
+++ b/src/db.rs
@@ -292,7 +292,7 @@ mod tests {
             )",
             params![],
         );
-        let num = conn.execute(
+        let _num = conn.execute(
             "INSERT INTO Currency (code, numeric_code, minor_unit, name) VALUES ('GBP', '826', '2', 'Pound Sterling');",
             params![],
         );
@@ -308,12 +308,12 @@ mod tests {
             params![],
         );
 
-        let num = conn.execute(
+        let _num = conn.execute(
             "INSERT INTO Accounts (type, name, currency) VALUES (0, \"Current\", \"GBP\")",
             params![],
         );
 
-        let num = conn.execute(
+        let _num = conn.execute(
             "INSERT INTO Accounts (type, name, currency) VALUES (1, \"Expenses\", \"GBP\")",
             params![],
         );

--- a/src/db.rs
+++ b/src/db.rs
@@ -50,22 +50,6 @@ pub fn list_transactions() -> Result<(Vec<Transaction>)> {
 
 pub fn get_account(
     conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    account: &str,
-) -> Result<(Account)> {
-    let mut stmt = conn.prepare("SELECT id, type, name, currency FROM Accounts WHERE name = ?1")?;
-
-    stmt.query_row(params![account], |row| {
-        Ok(Account {
-            id: row.get(0).unwrap(),
-            acc_type: AccountType::from_i32(row.get(1).unwrap()),
-            name: row.get(2).unwrap(),
-            currency: row.get(3).unwrap(),
-        })
-    })
-}
-
-pub fn get_account_by_id(
-    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
     id: i32,
 ) -> Result<(Account)> {
     let mut stmt = conn.prepare("SELECT id, type, name, currency FROM Accounts WHERE id = ?1")?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -98,18 +98,6 @@ pub fn add_account(
 
 pub fn remove_account(
     mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    name: &str,
-) -> Result<()> {
-    let con = conn.deref_mut();
-    let tx = con.transaction()?;
-
-    tx.execute("DELETE FROM Accounts WHERE Name = ?1", params![name])?;
-
-    tx.commit()
-}
-
-pub fn remove_account_by_id(
-    mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
     id: i32,
 ) -> Result<()> {
     let con = conn.deref_mut();

--- a/src/db.rs
+++ b/src/db.rs
@@ -353,6 +353,17 @@ mod tests {
     }
 
     #[test]
+    fn create_transaction_test() {
+        let manager = SqliteConnectionManager::memory();
+        let pool = r2d2::Pool::new(manager).unwrap();
+        create_base(pool.get().unwrap());
+
+        let id = transaction(pool.get().unwrap(), 1, 2, 50, "Super Payment");
+
+        assert_eq!(id.unwrap(), 1);
+    }
+
+    #[test]
     fn lists_currencies_returns_struct() {
         let manager = SqliteConnectionManager::memory();
         let pool = r2d2::Pool::new(manager).unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -29,7 +29,7 @@ pub fn list_accounts(
 
 pub fn list_transactions() -> Result<(Vec<Transaction>)> {
     let conn = Connection::open("ledger.db")?;
-    let mut stmt = conn.prepare("SELECT id, date, name from Transactions")?;
+    let mut stmt = conn.prepare("SELECT id, date, name from Transactions ORDER BY date DESC")?;
 
     let transactions = stmt
         .query_map(NO_PARAMS, |row| {
@@ -57,7 +57,7 @@ pub fn list_transactions_date(
         "SELECT id, date, name from Transactions
         WHERE CAST(strftime('%m', date) as integer) = ?1 
         AND CAST(strftime('%Y', date) as integer) = ?2 
-        ORDER BY date",
+        ORDER BY date DESC",
     )?;
 
     let transactions = stmt

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,14 @@ fn main() -> io::Result<()> {
             .service(
                 web::scope("/transactions")
                     .service(web::resource("").route(web::get().to_async(api::list_transactions)))
-                    .service(web::resource("/detail").route(web::get().to_async(api::list_transactions_with_details)))
+                    .service(
+                        web::resource("/detail")
+                            .route(web::get().to_async(api::list_transactions_with_details)),
+                    )
+                    .service(
+                        web::resource("/{year}/{month}")
+                            .route(web::get().to_async(api::get_transactions_date_scoped)),
+                    ),
             )
             .service(
                 web::scope("/transaction")

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,9 @@ fn main() -> io::Result<()> {
             .service(web::resource("/").route(web::get().to_async(api::index)))
             .service(web::resource("/currencies").route(web::get().to_async(api::list_currencies)))
             .service(
+                web::resource("/integrity").route(web::get().to_async(api::check_ledger_integrity)),
+            )
+            .service(
                 web::resource("/transactions").route(web::get().to_async(api::list_transactions)),
             )
             .service(

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,9 @@ fn main() -> io::Result<()> {
                 web::resource("/integrity").route(web::get().to_async(api::check_ledger_integrity)),
             )
             .service(
-                web::resource("/transactions").route(web::get().to_async(api::list_transactions)),
+                web::scope("/transactions")
+                    .service(web::resource("").route(web::get().to_async(api::list_transactions)))
+                    .service(web::resource("/detail").route(web::get().to_async(api::list_transactions_with_details)))
             )
             .service(
                 web::scope("/transaction")

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,10 @@ fn main() -> io::Result<()> {
             .wrap(Cors::new().send_wildcard().max_age(3600))
             .data(pool.clone())
             .service(web::resource("/").route(web::get().to_async(api::index)))
+            .service(web::resource("/currencies").route(web::get().to_async(api::list_currencies)))
             .service(
                 web::resource("/transactions").route(web::get().to_async(api::list_transactions)),
             )
-            .service(web::resource("/currencies").route(web::get().to_async(api::list_currencies)))
             .service(
                 web::scope("/transaction")
                     .service(

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> io::Result<()> {
             .service(
                 web::scope("/transaction")
                     .service(
-                        web::resource("/").route(web::post().to_async(api::create_transaction)),
+                        web::resource("").route(web::post().to_async(api::create_transaction)),
                     )
                     .service(
                         web::resource("/{id}")

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,7 @@ fn main() -> io::Result<()> {
             )
             .service(
                 web::scope("/transaction")
-                    .service(
-                        web::resource("").route(web::post().to_async(api::create_transaction)),
-                    )
+                    .service(web::resource("").route(web::post().to_async(api::create_transaction)))
                     .service(
                         web::resource("/{id}")
                             .route(web::get().to_async(api::get_transaction))


### PR DESCRIPTION
In this PR:
- Refactored the storage to use the lowest common currency denominator as an integer. (example Pennies for GBP) 
- Creating a transaction now returns the transaction id
- Added the list transactions with details method so we can get everything in the ledger in a single hit.
- Added some very basic unit tests
- Refactored the transactions entry objects. We no longer care return separate debits and credits. The Entry type enum now determines what type of a entry the entry is.
- We now returns entries as a list.
- We maintain that there should always be an even number of entries. 

Right now there are no limits to how we fetch transactions. This will be changed in next PRs. 