### PR TITLE
Refactor account into a separate module

### DIFF
--- a/src/account/data.rs
+++ b/src/account/data.rs
@@ -1,0 +1,35 @@
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Copy, Clone)]
+pub enum AccountType {
+    Assets,
+    Liabilities,
+    Equities,
+    Revenue,
+    Expenses,
+    Gains,
+    Losses,
+}
+impl AccountType {
+    pub fn from_i32(value: i32) -> AccountType {
+        match value {
+            0 => AccountType::Assets,
+            1 => AccountType::Liabilities,
+            2 => AccountType::Equities,
+            3 => AccountType::Revenue,
+            4 => AccountType::Expenses,
+            5 => AccountType::Gains,
+            6 => AccountType::Losses,
+            _ => panic!("Unknown value: {}", value),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct DetailedAccount {
+    pub id: i32,
+    pub acc_type: AccountType,
+    pub name: String,
+    pub balance: i32,
+    pub currency: String,
+}

--- a/src/account/data.rs
+++ b/src/account/data.rs
@@ -41,3 +41,10 @@ pub struct DetailedAccount {
     pub balance: i32,
     pub currency: String,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NewAccount {
+    pub acc_type: i32,
+    pub name: String,
+    pub currency: String,
+}

--- a/src/account/data.rs
+++ b/src/account/data.rs
@@ -26,6 +26,14 @@ impl AccountType {
 }
 
 #[derive(Debug, Serialize)]
+pub struct Account {
+    pub id: i32,
+    pub acc_type: AccountType,
+    pub name: String,
+    pub currency: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct DetailedAccount {
     pub id: i32,
     pub acc_type: AccountType,

--- a/src/account/data.rs
+++ b/src/account/data.rs
@@ -48,3 +48,27 @@ pub struct NewAccount {
     pub name: String,
     pub currency: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accounttype_correctly_types() {
+        let asset = AccountType::from_i32(0);
+        let liabilities = AccountType::from_i32(1);
+        let equities = AccountType::from_i32(2);
+        let revenue = AccountType::from_i32(3);
+        let expenses = AccountType::from_i32(4);
+        let gains = AccountType::from_i32(5);
+        let losses = AccountType::from_i32(6);
+
+        assert_eq!(asset, AccountType::Assets);
+        assert_eq!(liabilities, AccountType::Liabilities);
+        assert_eq!(equities, AccountType::Equities);
+        assert_eq!(revenue, AccountType::Revenue);
+        assert_eq!(expenses, AccountType::Expenses);
+        assert_eq!(gains, AccountType::Gains);
+        assert_eq!(losses, AccountType::Losses)
+    }
+}

--- a/src/account/db.rs
+++ b/src/account/db.rs
@@ -1,0 +1,31 @@
+use crate::account::data::{AccountType, DetailedAccount};
+use rusqlite::{params, Connection, Result, NO_PARAMS};
+
+pub fn list_accounts_filter_type(
+    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+    account_type: AccountType,
+) -> Result<(Vec<DetailedAccount>)> {
+    let mut stmt = conn.prepare("SELECT Accounts.id, Accounts.type, Accounts.name, Accounts.currency, 
+    (SELECT ifnull(SUM(balance),0) as \"Debits\" FROM Debits WHERE Debits.account = Accounts.id) - 
+    (SELECT ifnull(SUM(balance),0) as \"Credits\" FROM Credits WHERE Credits.account = Accounts.id) as \"balance\"
+    from Accounts WHERE type = ?1
+    ")?;
+
+    let accounts = stmt
+        .query_map(params![account_type as i32], |row| {
+            Ok(DetailedAccount {
+                id: row.get(0).unwrap(),
+                acc_type: AccountType::from_i32(row.get(1).unwrap()),
+                name: row.get(2).unwrap(),
+                currency: row.get(3).unwrap(),
+                balance: row.get(4).unwrap(),
+            })
+        })
+        .and_then(|mapped_rows| {
+            Ok(mapped_rows
+                .map(|row| row.unwrap())
+                .collect::<Vec<DetailedAccount>>())
+        })?;
+
+    Ok(accounts)
+}

--- a/src/account/db.rs
+++ b/src/account/db.rs
@@ -1,5 +1,28 @@
-use crate::account::data::{AccountType, DetailedAccount};
-use rusqlite::{params, Connection, Result, NO_PARAMS};
+use crate::account::data::{Account, AccountType, DetailedAccount};
+use rusqlite::{params, Result, NO_PARAMS};
+
+pub fn list_accounts(
+    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+) -> Result<(Vec<Account>)> {
+    let mut stmt = conn.prepare("SELECT id, type, name, currency from Accounts")?;
+
+    let accounts = stmt
+        .query_map(NO_PARAMS, |row| {
+            Ok(Account {
+                id: row.get(0).unwrap(),
+                acc_type: AccountType::from_i32(row.get(1).unwrap()),
+                name: row.get(2).unwrap(),
+                currency: row.get(3).unwrap(),
+            })
+        })
+        .and_then(|mapped_rows| {
+            Ok(mapped_rows
+                .map(|row| row.unwrap())
+                .collect::<Vec<Account>>())
+        })?;
+
+    Ok(accounts)
+}
 
 pub fn list_accounts_filter_type(
     conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,

--- a/src/account/db.rs
+++ b/src/account/db.rs
@@ -1,5 +1,55 @@
 use crate::account::data::{Account, AccountType, DetailedAccount};
 use rusqlite::{params, Result, NO_PARAMS};
+use std::ops::DerefMut;
+
+// Single Account Operations
+
+pub fn get_account(
+    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+    id: i32,
+) -> Result<(Account)> {
+    let mut stmt = conn.prepare("SELECT id, type, name, currency FROM Accounts WHERE id = ?1")?;
+
+    stmt.query_row(params![id], |row| {
+        Ok(Account {
+            id: row.get(0).unwrap(),
+            acc_type: AccountType::from_i32(row.get(1).unwrap()),
+            name: row.get(2).unwrap(),
+            currency: row.get(3).unwrap(),
+        })
+    })
+}
+
+pub fn add_account(
+    mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+    acc_type: AccountType,
+    name: &str,
+    currency: &str,
+) -> Result<()> {
+    let con = conn.deref_mut();
+    let tx = con.transaction()?;
+
+    tx.execute(
+        "INSERT INTO Accounts (type, name, currency) VALUES (?1, ?2, ?3)",
+        params![acc_type as i32, name, currency],
+    )?;
+
+    tx.commit()
+}
+
+pub fn remove_account(
+    mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+    id: i32,
+) -> Result<()> {
+    let con = conn.deref_mut();
+    let tx = con.transaction()?;
+
+    tx.execute("DELETE FROM Accounts WHERE id = ?1", params![id])?;
+
+    tx.commit()
+}
+
+// List Operations
 
 pub fn list_accounts(
     conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -7,6 +7,18 @@ use r2d2_sqlite::SqliteConnectionManager;
 pub mod data;
 mod db;
 
+pub fn list_accounts(
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let conn = pool.get().unwrap();
+    let result = db::list_accounts(conn);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
 pub fn list_asset_accounts(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1,0 +1,30 @@
+use actix_web::{web, Error, HttpResponse};
+use futures::future::ok;
+use futures::future::Future;
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+
+pub mod data;
+mod db;
+
+pub fn list_asset_accounts(
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let result = db::list_accounts_filter_type(pool.get().unwrap(), data::AccountType::Assets);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
+pub fn list_expense_accounts(
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let result = db::list_accounts_filter_type(pool.get().unwrap(), data::AccountType::Expenses);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -7,6 +7,51 @@ use r2d2_sqlite::SqliteConnectionManager;
 pub mod data;
 mod db;
 
+use crate::datastruct;
+
+pub fn get_account(
+    params: web::Path<datastruct::IdRequest>,
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let conn = pool.get().unwrap();
+    let result = db::get_account(conn, params.id);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
+pub fn create_account(
+    account: web::Json<data::NewAccount>,
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let account_type = data::AccountType::from_i32(account.acc_type);
+    let result = db::add_account(
+        pool.get().unwrap(),
+        account_type,
+        &account.name,
+        &account.currency,
+    );
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
+pub fn delete_account(
+    params: web::Path<datastruct::IdRequest>,
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let result = db::remove_account(pool.get().unwrap(), params.id);
+
+    match result {
+        Ok(_v) => ok(HttpResponse::Ok().finish()),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
 pub fn list_accounts(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -245,6 +245,18 @@ pub fn list_asset_accounts(
     }
 }
 
+pub fn list_expense_accounts(
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let result =
+        db::list_accounts_filter_type(pool.get().unwrap(), datastruct::AccountType::Expenses);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
 pub fn list_currencies(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,6 +8,7 @@ use serde_json::json;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
+use crate::account::data::AccountType;
 use crate::datastruct;
 use crate::db;
 
@@ -195,7 +196,7 @@ pub fn create_account(
     account: web::Json<datastruct::NewAccount>,
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    let account_type = datastruct::AccountType::from_i32(account.acc_type);
+    let account_type = AccountType::from_i32(account.acc_type);
     let result = db::add_account(
         pool.get().unwrap(),
         account_type,
@@ -233,23 +234,10 @@ pub fn get_account_balance(
     }
 }
 
-pub fn list_asset_accounts(
-    pool: web::Data<Pool<SqliteConnectionManager>>,
-) -> impl Future<Item = HttpResponse, Error = Error> {
-    let result =
-        db::list_accounts_filter_type(pool.get().unwrap(), datastruct::AccountType::Assets);
-
-    match result {
-        Ok(v) => ok(HttpResponse::Ok().json(v)),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
-    }
-}
-
 pub fn list_expense_accounts(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    let result =
-        db::list_accounts_filter_type(pool.get().unwrap(), datastruct::AccountType::Expenses);
+    let result = db::list_accounts_filter_type(pool.get().unwrap(), AccountType::Expenses);
 
     match result {
         Ok(v) => ok(HttpResponse::Ok().json(v)),
@@ -289,7 +277,8 @@ pub fn check_ledger_integrity(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datastruct::{Account, AccountType};
+    use crate::account::data::AccountType;
+    use crate::datastruct::Account;
 
     #[test]
     fn accounts_compatible() {

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
-use crate::account::data::{Account, AccountType};
+use crate::account::data::{Account};
 use crate::datastruct;
 use crate::db;
 
@@ -165,49 +165,6 @@ pub fn get_transaction_detail(
     });
 
     ok(HttpResponse::Ok().json(result))
-}
-
-pub fn get_account(
-    params: web::Path<datastruct::IdRequest>,
-    pool: web::Data<Pool<SqliteConnectionManager>>,
-) -> impl Future<Item = HttpResponse, Error = Error> {
-    let conn = pool.get().unwrap();
-    let result = db::get_account(conn, params.id);
-
-    match result {
-        Ok(v) => ok(HttpResponse::Ok().json(v)),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
-    }
-}
-
-pub fn create_account(
-    account: web::Json<datastruct::NewAccount>,
-    pool: web::Data<Pool<SqliteConnectionManager>>,
-) -> impl Future<Item = HttpResponse, Error = Error> {
-    let account_type = AccountType::from_i32(account.acc_type);
-    let result = db::add_account(
-        pool.get().unwrap(),
-        account_type,
-        &account.name,
-        &account.currency,
-    );
-
-    match result {
-        Ok(v) => ok(HttpResponse::Ok().json(v)),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
-    }
-}
-
-pub fn delete_account(
-    params: web::Path<datastruct::IdRequest>,
-    pool: web::Data<Pool<SqliteConnectionManager>>,
-) -> impl Future<Item = HttpResponse, Error = Error> {
-    let result = db::remove_account(pool.get().unwrap(), params.id);
-
-    match result {
-        Ok(_v) => ok(HttpResponse::Ok().finish()),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
-    }
 }
 
 pub fn get_account_balance(

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,21 +8,9 @@ use serde_json::json;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
-use crate::account::data::AccountType;
+use crate::account::data::{Account, AccountType};
 use crate::datastruct;
 use crate::db;
-
-pub fn index(
-    pool: web::Data<Pool<SqliteConnectionManager>>,
-) -> impl Future<Item = HttpResponse, Error = Error> {
-    let conn = pool.get().unwrap();
-    let result = db::list_accounts(conn);
-
-    match result {
-        Ok(v) => ok(HttpResponse::Ok().json(v)),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
-    }
-}
 
 pub fn list_transactions() -> impl Future<Item = HttpResponse, Error = Error> {
     let result = db::list_transactions();
@@ -84,7 +72,7 @@ pub fn get_transactions_date_scoped(
     }
 }
 
-fn are_accounts_compatible(from: &datastruct::Account, to: &datastruct::Account) -> bool {
+fn are_accounts_compatible(from: &Account, to: &Account) -> bool {
     if &from.id == &to.id || &from.currency != &to.currency {
         return false;
     }
@@ -234,17 +222,6 @@ pub fn get_account_balance(
     }
 }
 
-pub fn list_expense_accounts(
-    pool: web::Data<Pool<SqliteConnectionManager>>,
-) -> impl Future<Item = HttpResponse, Error = Error> {
-    let result = db::list_accounts_filter_type(pool.get().unwrap(), AccountType::Expenses);
-
-    match result {
-        Ok(v) => ok(HttpResponse::Ok().json(v)),
-        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
-    }
-}
-
 pub fn list_currencies(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
@@ -277,8 +254,8 @@ pub fn check_ledger_integrity(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::account::data::Account;
     use crate::account::data::AccountType;
-    use crate::datastruct::Account;
 
     #[test]
     fn accounts_compatible() {

--- a/src/api.rs
+++ b/src/api.rs
@@ -233,6 +233,18 @@ pub fn get_account_balance(
     }
 }
 
+pub fn list_asset_accounts(
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let result =
+        db::list_accounts_filter_type(pool.get().unwrap(), datastruct::AccountType::Assets);
+
+    match result {
+        Ok(v) => ok(HttpResponse::Ok().json(v)),
+        Err(_e) => ok(HttpResponse::InternalServerError().finish()),
+    }
+}
+
 pub fn list_currencies(
     pool: web::Data<Pool<SqliteConnectionManager>>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
-use crate::account::data::{Account};
+use crate::account::data::Account;
 use crate::datastruct;
 use crate::db;
 

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -26,13 +26,6 @@ pub struct NewTransaction {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct NewAccount {
-    pub acc_type: i32,
-    pub name: String,
-    pub currency: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct IdRequest {
     pub id: i32,
 }

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -1,8 +1,6 @@
 use chrono::Utc;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::account::data::AccountType;
-
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Copy, Clone)]
 pub enum EntryType {
     Debit,
@@ -17,14 +15,6 @@ impl EntryType {
             _ => panic!("Unknown value: {}", value),
         }
     }
-}
-
-#[derive(Debug, Serialize)]
-pub struct Account {
-    pub id: i32,
-    pub acc_type: AccountType,
-    pub name: String,
-    pub currency: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -95,7 +95,7 @@ pub struct Entry {
 
 #[derive(Debug, Serialize)]
 pub struct SqlResult {
-    pub value: f64,
+    pub value: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -51,6 +51,15 @@ pub struct Account {
     pub currency: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct DetailedAccount {
+    pub id: i32,
+    pub acc_type: AccountType,
+    pub name: String,
+    pub balance: i32,
+    pub currency: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NewTransaction {
     pub name: String,

--- a/src/datastruct.rs
+++ b/src/datastruct.rs
@@ -1,31 +1,7 @@
 use chrono::Utc;
-
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Copy, Clone)]
-pub enum AccountType {
-    Assets,
-    Liabilities,
-    Equities,
-    Revenue,
-    Expenses,
-    Gains,
-    Losses,
-}
-impl AccountType {
-    pub fn from_i32(value: i32) -> AccountType {
-        match value {
-            0 => AccountType::Assets,
-            1 => AccountType::Liabilities,
-            2 => AccountType::Equities,
-            3 => AccountType::Revenue,
-            4 => AccountType::Expenses,
-            5 => AccountType::Gains,
-            6 => AccountType::Losses,
-            _ => panic!("Unknown value: {}", value),
-        }
-    }
-}
+use crate::account::data::AccountType;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Copy, Clone)]
 pub enum EntryType {
@@ -48,15 +24,6 @@ pub struct Account {
     pub id: i32,
     pub acc_type: AccountType,
     pub name: String,
-    pub currency: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct DetailedAccount {
-    pub id: i32,
-    pub acc_type: AccountType,
-    pub name: String,
-    pub balance: i32,
     pub currency: String,
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,6 @@
-use crate::datastruct::{Account, AccountType, Currency, Entry, EntryType, SqlResult, Transaction};
+use crate::datastruct::{
+    Account, AccountType, DetailedAccount, Currency, Entry, EntryType, SqlResult, Transaction,
+};
 use rusqlite::{params, Connection, Result, NO_PARAMS};
 
 use chrono::{DateTime, Utc};
@@ -30,22 +32,27 @@ pub fn list_accounts(
 pub fn list_accounts_filter_type(
     conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
     account_type: AccountType,
-) -> Result<(Vec<Account>)> {
-    let mut stmt = conn.prepare("SELECT id, type, name, currency from Accounts WHERE type = ?1")?;
+) -> Result<(Vec<DetailedAccount>)> {
+    let mut stmt = conn.prepare("SELECT Accounts.id, Accounts.type, Accounts.name, Accounts.currency, 
+    (SELECT ifnull(SUM(balance),0) as \"Debits\" FROM Debits WHERE Debits.account = Accounts.id) - 
+    (SELECT ifnull(SUM(balance),0) as \"Credits\" FROM Credits WHERE Credits.account = Accounts.id) as \"balance\"
+    from Accounts WHERE type = ?1
+    ")?;
 
     let accounts = stmt
         .query_map(params![account_type as i32], |row| {
-            Ok(Account {
+            Ok(DetailedAccount {
                 id: row.get(0).unwrap(),
                 acc_type: AccountType::from_i32(row.get(1).unwrap()),
                 name: row.get(2).unwrap(),
                 currency: row.get(3).unwrap(),
+                balance: row.get(4).unwrap(),
             })
         })
         .and_then(|mapped_rows| {
             Ok(mapped_rows
                 .map(|row| row.unwrap())
-                .collect::<Vec<Account>>())
+                .collect::<Vec<DetailedAccount>>())
         })?;
 
     Ok(accounts)

--- a/src/db.rs
+++ b/src/db.rs
@@ -88,35 +88,6 @@ pub fn get_transaction(
     })
 }
 
-pub fn add_account(
-    mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    acc_type: AccountType,
-    name: &str,
-    currency: &str,
-) -> Result<()> {
-    let con = conn.deref_mut();
-    let tx = con.transaction()?;
-
-    tx.execute(
-        "INSERT INTO Accounts (type, name, currency) VALUES (?1, ?2, ?3)",
-        params![acc_type as i32, name, currency],
-    )?;
-
-    tx.commit()
-}
-
-pub fn remove_account(
-    mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    id: i32,
-) -> Result<()> {
-    let con = conn.deref_mut();
-    let tx = con.transaction()?;
-
-    tx.execute("DELETE FROM Accounts WHERE id = ?1", params![id])?;
-
-    tx.commit()
-}
-
 pub fn transaction(
     mut conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
     debit_account: i32,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,63 +1,11 @@
-use crate::datastruct::{Account, Currency, Entry, EntryType, SqlResult, Transaction};
+use crate::datastruct::{Currency, Entry, EntryType, SqlResult, Transaction};
 
-use crate::account::data::{AccountType, DetailedAccount};
+use crate::account::data::{Account, AccountType};
 
 use rusqlite::{params, Connection, Result, NO_PARAMS};
 
 use chrono::{DateTime, Utc};
 use std::ops::DerefMut;
-
-pub fn list_accounts(
-    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-) -> Result<(Vec<Account>)> {
-    let mut stmt = conn.prepare("SELECT id, type, name, currency from Accounts")?;
-
-    let accounts = stmt
-        .query_map(NO_PARAMS, |row| {
-            Ok(Account {
-                id: row.get(0).unwrap(),
-                acc_type: AccountType::from_i32(row.get(1).unwrap()),
-                name: row.get(2).unwrap(),
-                currency: row.get(3).unwrap(),
-            })
-        })
-        .and_then(|mapped_rows| {
-            Ok(mapped_rows
-                .map(|row| row.unwrap())
-                .collect::<Vec<Account>>())
-        })?;
-
-    Ok(accounts)
-}
-
-pub fn list_accounts_filter_type(
-    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    account_type: AccountType,
-) -> Result<(Vec<DetailedAccount>)> {
-    let mut stmt = conn.prepare("SELECT Accounts.id, Accounts.type, Accounts.name, Accounts.currency, 
-    (SELECT ifnull(SUM(balance),0) as \"Debits\" FROM Debits WHERE Debits.account = Accounts.id) - 
-    (SELECT ifnull(SUM(balance),0) as \"Credits\" FROM Credits WHERE Credits.account = Accounts.id) as \"balance\"
-    from Accounts WHERE type = ?1
-    ")?;
-
-    let accounts = stmt
-        .query_map(params![account_type as i32], |row| {
-            Ok(DetailedAccount {
-                id: row.get(0).unwrap(),
-                acc_type: AccountType::from_i32(row.get(1).unwrap()),
-                name: row.get(2).unwrap(),
-                currency: row.get(3).unwrap(),
-                balance: row.get(4).unwrap(),
-            })
-        })
-        .and_then(|mapped_rows| {
-            Ok(mapped_rows
-                .map(|row| row.unwrap())
-                .collect::<Vec<DetailedAccount>>())
-        })?;
-
-    Ok(accounts)
-}
 
 pub fn list_transactions() -> Result<(Vec<Transaction>)> {
     let conn = Connection::open("ledger.db")?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -227,7 +227,7 @@ pub fn check_integrity(
                 .collect::<Vec<SqlResult>>())
         })?;
 
-    let result = if query[0].value == 0. { true } else { false };
+    let result = if query[0].value == 0 { true } else { false };
 
     Ok(result)
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,7 @@
-use crate::datastruct::{
-    Account, AccountType, DetailedAccount, Currency, Entry, EntryType, SqlResult, Transaction,
-};
+use crate::datastruct::{Account, Currency, Entry, EntryType, SqlResult, Transaction};
+
+use crate::account::data::{AccountType, DetailedAccount};
+
 use rusqlite::{params, Connection, Result, NO_PARAMS};
 
 use chrono::{DateTime, Utc};

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> io::Result<()> {
             .wrap(Logger::default())
             .wrap(Cors::new().send_wildcard().max_age(3600))
             .data(pool.clone())
-            .service(web::resource("/").route(web::get().to_async(api::index)))
+            .service(web::resource("/").route(web::get().to_async(account::list_accounts)))
             .service(web::resource("/currencies").route(web::get().to_async(api::list_currencies)))
             .service(
                 web::resource("/integrity").route(web::get().to_async(api::check_ledger_integrity)),
@@ -92,7 +92,7 @@ fn main() -> io::Result<()> {
             )
             .service(
                 web::scope("/accounts")
-                    .service(web::resource("").route(web::get().to_async(api::index)))
+                    .service(web::resource("").route(web::get().to_async(account::list_accounts)))
                     .service(
                         web::resource("/asset")
                             .route(web::get().to_async(account::list_asset_accounts)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,14 @@ fn main() -> io::Result<()> {
                             .route(web::get().to_async(api::get_account_balance)),
                     ),
             )
+            .service(
+                web::scope("/accounts")
+                    .service(web::resource("").route(web::get().to_async(api::index)))
+                    .service(
+                        web::resource("/asset")
+                            .route(web::get().to_async(api::list_asset_accounts)),
+                    ),
+            )
     };
 
     debug!("Starting server");

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,9 @@ fn main() -> io::Result<()> {
             )
             .service(
                 web::scope("/account")
-                    .service(web::resource("/").route(web::post().to_async(account::create_account)))
+                    .service(
+                        web::resource("/").route(web::post().to_async(account::create_account)),
+                    )
                     .service(
                         web::resource("/{id}")
                             .route(web::get().to_async(account::get_account))

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,10 @@ fn main() -> io::Result<()> {
                     .service(
                         web::resource("/asset")
                             .route(web::get().to_async(api::list_asset_accounts)),
+                    )
+                    .service(
+                        web::resource("/expense")
+                            .route(web::get().to_async(api::list_expense_accounts)),
                     ),
             )
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@
 extern crate chrono;
 extern crate rusqlite;
 
+mod account;
 mod api;
 mod datastruct;
 mod db;
@@ -94,11 +95,11 @@ fn main() -> io::Result<()> {
                     .service(web::resource("").route(web::get().to_async(api::index)))
                     .service(
                         web::resource("/asset")
-                            .route(web::get().to_async(api::list_asset_accounts)),
+                            .route(web::get().to_async(account::list_asset_accounts)),
                     )
                     .service(
                         web::resource("/expense")
-                            .route(web::get().to_async(api::list_expense_accounts)),
+                            .route(web::get().to_async(account::list_expense_accounts)),
                     ),
             )
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,11 +79,11 @@ fn main() -> io::Result<()> {
             )
             .service(
                 web::scope("/account")
-                    .service(web::resource("/").route(web::post().to_async(api::create_account)))
+                    .service(web::resource("/").route(web::post().to_async(account::create_account)))
                     .service(
                         web::resource("/{id}")
-                            .route(web::get().to_async(api::get_account))
-                            .route(web::delete().to_async(api::delete_account)),
+                            .route(web::get().to_async(account::get_account))
+                            .route(web::delete().to_async(account::delete_account)),
                     )
                     .service(
                         web::resource("/{id}/balance")


### PR DESCRIPTION
In this PR:
- Move all methods and structs used for the account logic in the API, db and data into a separate module.
- Added a separate api calls for the asset and expense accounts (this will be later changed to a query) 
- Refactored any links in the old module
- Added tests (they are ugly but they will do for now)